### PR TITLE
Add pull_images.sh script for downloading and cleaning up generated images

### DIFF
--- a/scripts/pull_images.sh
+++ b/scripts/pull_images.sh
@@ -1,0 +1,25 @@
+# Check if required variables are set
+required_variables=("singapore_home_user" "singapore_home_ip" "singapore_home_port")
+
+for var_name in "${required_variables[@]}"; do
+    if [ -z "${!var_name}" ]; then
+        echo "Error: Missing required variable '$var_name'. Please set it before running the script."
+        exit 1
+    fi
+done
+
+
+# Set up the SSH parameters for the remote machine
+singapore_ssh_params="${singapore_home_user}@${singapore_home_ip}"
+
+# List the image files in the ~/tmp/generated_pics/ directory on the remote machine and save the output to a local file called images_to_pull
+ssh -p ${singapore_home_port} ${singapore_ssh_params} "ls ~/tmp/generated_pics/*.png" > images_to_pull
+
+# Download each image to the local machine using rsync
+for image in $(cat images_to_pull)
+do
+  rsync -avz -e "ssh -p ${singapore_home_port}" ${singapore_ssh_params}:${image} ./
+done
+
+# Remove all image files in the ~/tmp/generated_pics/ directory on the remote machine
+ssh -p ${singapore_home_port} ${singapore_ssh_params} "rm -rf ~/tmp/generated_pics/*.png"


### PR DESCRIPTION

## Description:
This commit adds the pull_images.sh script, which is responsible for downloading AI-generated images from a remote machine and cleaning up the remote storage directory.

## Key features:

Checks for required variables and exits with an error message if any are missing. Sets up SSH parameters for the remote machine.
Lists image files in the remote ~/tmp/generated_pics/ directory and saves the output to a local file called images_to_pull. Downloads each image to the local machine using Rsync. Removes all image files in the remote ~/tmp/generated_pics/ directory after downloading. By adding this script, users can easily download generated images to their local machine and ensure that the remote storage directory remains clean and organized.